### PR TITLE
PAE-671 - Add space for activetable xblock

### DIFF
--- a/recap/static/css/recap.css
+++ b/recap/static/css/recap.css
@@ -79,6 +79,10 @@ table.recap-tab th {
   padding: 8px;
 }
 
+.active-table-custom-format-cell {
+  line-height: 50px;
+}
+
 table.recap-tab tr:nth-child(even) {
   background-color: #dddddd;
 }


### PR DESCRIPTION
Description
---------------
This prevents the text from being cut between pages of the PDF generated by recap.

**Ticket:** [PAE-671](https://pearsonadvance.atlassian.net/browse/PAE-671)